### PR TITLE
Qi1-38-blog 글쓰기 페이지 레이아웃 구현

### DIFF
--- a/app/(shared)/components/BlogCard.tsx
+++ b/app/(shared)/components/BlogCard.tsx
@@ -49,22 +49,25 @@ interface BlogCardProps {
 export const BlogCard = ({ post, onClick }: BlogCardProps) => {
   return (
     <div
-      className="bg-white rounded-lg shadow-lg overflow-hidden hover:shadow-xl transition-shadow duration-300 cursor-pointer group"
+      className="relative rounded-lg shadow-lg overflow-hidden hover:shadow-xl transition-shadow duration-300 cursor-pointer group aspect-square"
       onClick={onClick}
     >
-      <div className="relative h-48 bg-gray-100 overflow-hidden">
-        <Image
-          src={post.image}
-          alt={post.title}
-          fill
-          className="object-cover transition-transform duration-300 group-hover:scale-105"
-        />
-      </div>
-      <div className="p-6">
-        <h3 className="text-lg font-semibold text-gray-800 mb-2 line-clamp-2">
+      {/* 이미지 */}
+      <Image
+        src={post.image}
+        alt={post.title}
+        fill
+        className="object-cover w-full h-full transition-transform duration-300 group-hover:scale-105"
+        priority
+      />
+      {/* 텍스트 오버레이 */}
+      <div className="absolute inset-0 flex flex-col justify-end bg-gradient-to-t from-black/70 via-black/30 to-transparent p-5">
+        <h3 className="text-white text-lg font-semibold mb-2 drop-shadow-md line-clamp-2">
           {post.title}
         </h3>
-        <p className="text-sm text-gray-600">{post.subtitle}</p>
+        <p className="text-white text-sm font-medium drop-shadow-md flex items-center gap-1">
+          {post.subtitle}
+        </p>
       </div>
     </div>
   );

--- a/app/(shared)/components/BlogCard.tsx
+++ b/app/(shared)/components/BlogCard.tsx
@@ -1,0 +1,71 @@
+import Image from 'next/image';
+
+/**
+ * 블로그 포스트 데이터 타입
+ */
+export interface BlogPost {
+  /** 포스트 고유 식별자 */
+  id: number;
+  /** 포스트 제목 */
+  title: string;
+  /** 포스트 부제목 또는 설명 */
+  subtitle: string;
+  /** 포스트 대표 이미지 경로 */
+  image: string;
+  /** 추천 포스트 여부 */
+  featured: boolean;
+}
+
+/**
+ * BlogCard 컴포넌트 Props
+ */
+interface BlogCardProps {
+  /** 렌더링할 블로그 포스트 데이터 */
+  post: BlogPost;
+  /** 카드 클릭 시 실행할 콜백 함수 */
+  onClick?: () => void;
+}
+
+/**
+ * 블로그 포스트를 카드 형태로 렌더링하는 컴포넌트
+ *
+ * @param props - BlogCard 컴포넌트 props
+ * @returns 블로그 카드 JSX 엘리먼트
+ *
+ * @example
+ * ```tsx
+ * <BlogCard
+ *   post={{
+ *     id: 1,
+ *     title: "포스트 제목",
+ *     subtitle: "포스트 설명",
+ *     image: "/image.jpg",
+ *     featured: true
+ *   }}
+ *   onClick={() => console.log('카드 클릭됨')}
+ * />
+ * ```
+ */
+export const BlogCard = ({ post, onClick }: BlogCardProps) => {
+  return (
+    <div
+      className="bg-white rounded-lg shadow-lg overflow-hidden hover:shadow-xl transition-shadow duration-300 cursor-pointer"
+      onClick={onClick}
+    >
+      <div className="relative h-48 bg-gray-100">
+        <Image
+          src={post.image}
+          alt={post.title}
+          fill
+          className="object-cover"
+        />
+      </div>
+      <div className="p-6">
+        <h3 className="text-lg font-semibold text-gray-800 mb-2 line-clamp-2">
+          {post.title}
+        </h3>
+        <p className="text-sm text-gray-600">{post.subtitle}</p>
+      </div>
+    </div>
+  );
+};

--- a/app/(shared)/components/BlogCard.tsx
+++ b/app/(shared)/components/BlogCard.tsx
@@ -49,15 +49,15 @@ interface BlogCardProps {
 export const BlogCard = ({ post, onClick }: BlogCardProps) => {
   return (
     <div
-      className="bg-white rounded-lg shadow-lg overflow-hidden hover:shadow-xl transition-shadow duration-300 cursor-pointer"
+      className="bg-white rounded-lg shadow-lg overflow-hidden hover:shadow-xl transition-shadow duration-300 cursor-pointer group"
       onClick={onClick}
     >
-      <div className="relative h-48 bg-gray-100">
+      <div className="relative h-48 bg-gray-100 overflow-hidden">
         <Image
           src={post.image}
           alt={post.title}
           fill
-          className="object-cover"
+          className="object-cover transition-transform duration-300 group-hover:scale-105"
         />
       </div>
       <div className="p-6">

--- a/app/(shared)/components/SortDropdown.tsx
+++ b/app/(shared)/components/SortDropdown.tsx
@@ -1,0 +1,68 @@
+import Image from 'next/image';
+
+export interface SortOption {
+  value: string;
+  label: string;
+}
+
+interface SortDropdownProps {
+  options: SortOption[];
+  defaultValue?: string;
+  onChange?: (value: string) => void;
+  className?: string;
+  disabled?: boolean;
+}
+
+/**
+ * 재사용 가능한 정렬 드롭다운 컴포넌트
+ *
+ * @param props - SortDropdown 컴포넌트 props
+ * @returns 정렬 드롭다운 JSX 엘리먼트
+ *
+ * @example
+ * ```tsx
+ * <SortDropdown
+ *   options={[
+ *     { value: 'latest', label: '최신순' },
+ *     { value: 'popular', label: '인기순' }
+ *   ]}
+ *   defaultValue="latest"
+ *   onChange={(value) => console.log('정렬:', value)}
+ * />
+ * ```
+ */
+export const SortDropdown = ({
+  options,
+  defaultValue,
+  onChange,
+  className = '',
+  disabled = false,
+}: SortDropdownProps) => {
+  return (
+    <div className={`relative ${className}`}>
+      <select
+        className="appearance-none bg-white border rounded-lg px-4 py-2 pr-10 text-sm font-medium text-gray-700 focus:outline-none  cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+        defaultValue={defaultValue}
+        onChange={(e) => onChange?.(e.target.value)}
+        disabled={disabled}
+      >
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+
+      {/* 커스텀 드롭다운 아이콘 */}
+      <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3">
+        <Image
+          src="/chevron-down.svg"
+          alt="chevron down"
+          width={16}
+          height={16}
+          className="w-4 h-4"
+        />
+      </div>
+    </div>
+  );
+};

--- a/app/blog/components/BlogContent.tsx
+++ b/app/blog/components/BlogContent.tsx
@@ -2,17 +2,13 @@
 
 import { useState } from 'react';
 import { BlogCard, BlogPost } from '@/app/(shared)/components/BlogCard';
+import { BlogTabNavigation } from './BlogTabNavigation';
 
-/**
- * BlogContent 컴포넌트 Props
- */
 interface BlogContentProps {
-  /** 렌더링할 블로그 포스트 배열 */
   posts: BlogPost[];
-  /** 'Show more' 버튼 클릭 시 실행할 콜백 함수 */
   onShowMore?: () => void;
-  /** 개별 포스트 클릭 시 실행할 콜백 함수 */
   onPostClick?: (post: BlogPost) => void;
+  onSortChange?: (sortBy: string) => void;
 }
 
 /**
@@ -26,6 +22,7 @@ export const BlogContent = ({
   posts,
   onShowMore,
   onPostClick,
+  onSortChange,
 }: BlogContentProps) => {
   const [activeTab, setActiveTab] = useState<'all' | 'featured'>('all');
 
@@ -36,42 +33,18 @@ export const BlogContent = ({
     onPostClick?.(post);
   };
 
+  const handleTabChange = (tab: 'all' | 'featured') => {
+    setActiveTab(tab);
+  };
+
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
       {/* 탭 네비게이션 */}
-      <div className="flex items-center justify-between mb-8">
-        <div className="flex space-x-8">
-          <button
-            onClick={() => setActiveTab('all')}
-            className={`text-lg font-medium pb-2 border-b-2 transition-colors ${
-              activeTab === 'all'
-                ? 'text-gray-800 border-gray-800'
-                : 'text-gray-500 border-transparent hover:text-gray-700'
-            }`}
-          >
-            모든글
-          </button>
-          <button
-            onClick={() => setActiveTab('featured')}
-            className={`text-lg font-medium pb-2 border-b-2 transition-colors ${
-              activeTab === 'featured'
-                ? 'text-gray-800 border-gray-800'
-                : 'text-gray-500 border-transparent hover:text-gray-700'
-            }`}
-          >
-            Featured
-          </button>
-        </div>
-
-        <div className="flex items-center space-x-4">
-          <span className="text-sm text-gray-500">Sort by</span>
-          <select className="border border-gray-300 rounded-lg px-3 py-1 text-sm">
-            <option>최신순</option>
-            <option>인기순</option>
-            <option>조회순</option>
-          </select>
-        </div>
-      </div>
+      <BlogTabNavigation
+        activeTab={activeTab}
+        onTabChange={handleTabChange}
+        onSortChange={onSortChange}
+      />
 
       {/* 블로그 카드 그리드 */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mb-12">

--- a/app/blog/components/BlogContent.tsx
+++ b/app/blog/components/BlogContent.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useState } from 'react';
+import { BlogCard, BlogPost } from '@/app/(shared)/components/BlogCard';
+
+/**
+ * BlogContent 컴포넌트 Props
+ */
+interface BlogContentProps {
+  /** 렌더링할 블로그 포스트 배열 */
+  posts: BlogPost[];
+  /** 'Show more' 버튼 클릭 시 실행할 콜백 함수 */
+  onShowMore?: () => void;
+  /** 개별 포스트 클릭 시 실행할 콜백 함수 */
+  onPostClick?: (post: BlogPost) => void;
+}
+
+/**
+ * 블로그 메인 콘텐츠 컴포넌트
+ * 탭 네비게이션, 블로그 카드 그리드, Show more 버튼을 포함
+ *
+ * @param props - BlogContent 컴포넌트 props
+ * @returns 블로그 메인 콘텐츠 JSX 엘리먼트
+ */
+export const BlogContent = ({
+  posts,
+  onShowMore,
+  onPostClick,
+}: BlogContentProps) => {
+  const [activeTab, setActiveTab] = useState<'all' | 'featured'>('all');
+
+  const filteredPosts =
+    activeTab === 'all' ? posts : posts.filter((post) => post.featured);
+
+  const handlePostClick = (post: BlogPost) => {
+    onPostClick?.(post);
+  };
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+      {/* 탭 네비게이션 */}
+      <div className="flex items-center justify-between mb-8">
+        <div className="flex space-x-8">
+          <button
+            onClick={() => setActiveTab('all')}
+            className={`text-lg font-medium pb-2 border-b-2 transition-colors ${
+              activeTab === 'all'
+                ? 'text-gray-800 border-gray-800'
+                : 'text-gray-500 border-transparent hover:text-gray-700'
+            }`}
+          >
+            모든글
+          </button>
+          <button
+            onClick={() => setActiveTab('featured')}
+            className={`text-lg font-medium pb-2 border-b-2 transition-colors ${
+              activeTab === 'featured'
+                ? 'text-gray-800 border-gray-800'
+                : 'text-gray-500 border-transparent hover:text-gray-700'
+            }`}
+          >
+            Featured
+          </button>
+        </div>
+
+        <div className="flex items-center space-x-4">
+          <span className="text-sm text-gray-500">Sort by</span>
+          <select className="border border-gray-300 rounded-lg px-3 py-1 text-sm">
+            <option>최신순</option>
+            <option>인기순</option>
+            <option>조회순</option>
+          </select>
+        </div>
+      </div>
+
+      {/* 블로그 카드 그리드 */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mb-12">
+        {filteredPosts.map((post) => (
+          <BlogCard
+            key={post.id}
+            post={post}
+            onClick={() => handlePostClick(post)}
+          />
+        ))}
+      </div>
+
+      {/* Show more 버튼 */}
+      <div className="text-center">
+        <button
+          onClick={onShowMore}
+          className="bg-white border-2 border-gray-300 text-gray-700 px-8 py-3 rounded-full font-medium hover:bg-gray-50 transition-colors"
+        >
+          Show more
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/app/blog/components/BlogHero.tsx
+++ b/app/blog/components/BlogHero.tsx
@@ -1,0 +1,27 @@
+interface BlogHeroProps {
+  title?: string;
+  subtitle?: string;
+}
+
+export const BlogHero = ({
+  title = 'snac 읽을거리',
+  subtitle = '간식처럼 가볍게 읽어보세요',
+}: BlogHeroProps) => {
+  return (
+    <div className="relative bg-gradient-to-r from-gray-100 to-gray-200 py-20">
+      <div className="absolute inset-0 bg-[url('/blog-bg-pattern.svg')] bg-repeat opacity-10"></div>
+      <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+        <nav className="flex justify-center space-x-2 text-sm text-gray-500 mb-8">
+          <span>Home</span>
+          <span>→</span>
+          <span className="text-gray-700">Blog</span>
+        </nav>
+
+        <h1 className="text-4xl md:text-5xl font-bold text-gray-800 mb-4">
+          {title}
+        </h1>
+        <p className="text-xl text-gray-600 max-w-2xl mx-auto">{subtitle}</p>
+      </div>
+    </div>
+  );
+};

--- a/app/blog/components/BlogHero.tsx
+++ b/app/blog/components/BlogHero.tsx
@@ -1,8 +1,19 @@
+/**
+ * BlogHero 컴포넌트 Props
+ */
 interface BlogHeroProps {
+  /** 히어로 섹션 제목 */
   title?: string;
+  /** 히어로 섹션 부제목 */
   subtitle?: string;
 }
 
+/**
+ * 블로그 페이지 히어로 섹션 컴포넌트
+ *
+ * @param props - BlogHero 컴포넌트 props
+ * @returns 히어로 섹션 JSX 엘리먼트
+ */
 export const BlogHero = ({
   title = 'snac 읽을거리',
   subtitle = '간식처럼 가볍게 읽어보세요',

--- a/app/blog/components/BlogHero.tsx
+++ b/app/blog/components/BlogHero.tsx
@@ -1,10 +1,5 @@
-/**
- * BlogHero 컴포넌트 Props
- */
 interface BlogHeroProps {
-  /** 히어로 섹션 제목 */
   title?: string;
-  /** 히어로 섹션 부제목 */
   subtitle?: string;
 }
 

--- a/app/blog/components/BlogTabNavigation.tsx
+++ b/app/blog/components/BlogTabNavigation.tsx
@@ -1,0 +1,63 @@
+import {
+  SortDropdown,
+  SortOption,
+} from '@/app/(shared)/components/SortDropdown';
+
+interface BlogTabNavigationProps {
+  activeTab: 'all' | 'featured';
+  onTabChange: (tab: 'all' | 'featured') => void;
+  onSortChange?: (sortBy: string) => void;
+}
+
+const blogSortOptions: SortOption[] = [
+  { value: 'latest', label: '최신순' },
+  { value: 'popular', label: '인기순' },
+  { value: 'views', label: '조회순' },
+];
+
+/**
+ * 블로그 탭 네비게이션 및 정렬 컴포넌트
+ *
+ * @param props - BlogTabNavigation 컴포넌트 props
+ * @returns 탭 네비게이션 JSX 엘리먼트
+ */
+export const BlogTabNavigation = ({
+  activeTab,
+  onTabChange,
+  onSortChange,
+}: BlogTabNavigationProps) => {
+  return (
+    <div className="flex items-center justify-between mb-8">
+      {/* 탭 네비게이션 */}
+      <div className="flex space-x-8">
+        <button
+          onClick={() => onTabChange('all')}
+          className={`text-lg font-medium pb-2 border-b-2 transition-colors ${
+            activeTab === 'all'
+              ? 'text-gray-800 border-gray-800'
+              : 'text-gray-500 border-transparent hover:text-gray-700'
+          }`}
+        >
+          모든글
+        </button>
+        <button
+          onClick={() => onTabChange('featured')}
+          className={`text-lg font-medium pb-2 border-b-2 transition-colors ${
+            activeTab === 'featured'
+              ? 'text-gray-800 border-gray-800'
+              : 'text-gray-500 border-transparent hover:text-gray-700'
+          }`}
+        >
+          Featured
+        </button>
+      </div>
+
+      {/* 정렬 옵션 */}
+      <SortDropdown
+        options={blogSortOptions}
+        defaultValue="latest"
+        onChange={onSortChange}
+      />
+    </div>
+  );
+};

--- a/app/blog/data/blogPosts.ts
+++ b/app/blog/data/blogPosts.ts
@@ -65,13 +65,3 @@ export const blogPosts: BlogPost[] = [
     featured: true,
   },
 ];
-
-// 추가 유틸리티 함수들
-export const getFeaturedPosts = () => blogPosts.filter((post) => post.featured);
-export const getPostById = (id: number) =>
-  blogPosts.find((post) => post.id === id);
-export const getPostsByPage = (page: number, limit: number = 9) => {
-  const start = (page - 1) * limit;
-  const end = start + limit;
-  return blogPosts.slice(start, end);
-};

--- a/app/blog/data/blogPosts.ts
+++ b/app/blog/data/blogPosts.ts
@@ -1,0 +1,77 @@
+import { BlogPost } from '@/app/(shared)/components/BlogCard';
+
+export const blogPosts: BlogPost[] = [
+  {
+    id: 1,
+    title: '데이터 기반 아웃렛 마케팅은?',
+    subtitle: '더 보기 →',
+    image: '/blog1.png',
+    featured: true,
+  },
+  {
+    id: 2,
+    title: '데이터 기반 아웃렛 마케팅은?',
+    subtitle: '더 보기 →',
+    image: '/blog2.png',
+    featured: false,
+  },
+  {
+    id: 3,
+    title: '데이터 기반 아웃렛 마케팅은?',
+    subtitle: '더 보기 →',
+    image: '/blog3.png',
+    featured: true,
+  },
+  {
+    id: 4,
+    title: '데이터 기반 아웃렛 마케팅은?',
+    subtitle: '더 보기 →',
+    image: '/blog1.png',
+    featured: false,
+  },
+  {
+    id: 5,
+    title: '데이터 기반 아웃렛 마케팅은?',
+    subtitle: '더 보기 →',
+    image: '/blog2.png',
+    featured: true,
+  },
+  {
+    id: 6,
+    title: '데이터 기반 아웃렛 마케팅은?',
+    subtitle: '더 보기 →',
+    image: '/blog3.png',
+    featured: false,
+  },
+  {
+    id: 7,
+    title: '데이터 기반 아웃렛 마케팅은?',
+    subtitle: '더 보기 →',
+    image: '/blog1.png',
+    featured: true,
+  },
+  {
+    id: 8,
+    title: '데이터 기반 아웃렛 마케팅은?',
+    subtitle: '더 보기 →',
+    image: '/blog2.png',
+    featured: false,
+  },
+  {
+    id: 9,
+    title: '데이터 기반 아웃렛 마케팅은?',
+    subtitle: '더 보기 →',
+    image: '/blog3.png',
+    featured: true,
+  },
+];
+
+// 추가 유틸리티 함수들
+export const getFeaturedPosts = () => blogPosts.filter((post) => post.featured);
+export const getPostById = (id: number) =>
+  blogPosts.find((post) => post.id === id);
+export const getPostsByPage = (page: number, limit: number = 9) => {
+  const start = (page - 1) * limit;
+  const end = start + limit;
+  return blogPosts.slice(start, end);
+};

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,8 +1,34 @@
+'use client';
+
+import { Footer } from '@/app/(shared)/components/Footer';
+import { Header } from '@/app/(shared)/components/Header';
+import { BlogPost } from '@/app/(shared)/components/BlogCard';
+import { BlogHero } from './components/BlogHero';
+import { BlogContent } from './components/BlogContent';
+import { blogPosts } from './data/blogPosts';
+
 export default function BlogPage() {
+  const handleShowMore = () => {
+    console.log('Show more clicked!');
+    // 여기에 더 많은 포스트를 로드하는 로직 추가
+  };
+
+  const handlePostClick = (post: BlogPost) => {
+    console.log('Post clicked:', post.title);
+    // 여기에 개별 포스트 페이지로 이동하는 로직 추가
+    // 예: router.push(`/blog/${post.id}`)
+  };
+
   return (
-    <div>
-      <h1>블로그</h1>
-      <p>블로그 페이지입니다.</p>
+    <div className="min-h-screen bg-gray-50">
+      <Header />
+      <BlogHero />
+      <BlogContent
+        posts={blogPosts}
+        onShowMore={handleShowMore}
+        onPostClick={handlePostClick}
+      />
+      <Footer />
     </div>
-  )
+  );
 }

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -19,6 +19,11 @@ export default function BlogPage() {
     // 예: router.push(`/blog/${post.id}`)
   };
 
+  const handleSortChange = (sortBy: string) => {
+    console.log('Sort changed to:', sortBy);
+    // 여기에 정렬 로직 추가
+  };
+
   return (
     <div className="min-h-screen bg-gray-50">
       <Header />
@@ -27,6 +32,7 @@ export default function BlogPage() {
         posts={blogPosts}
         onShowMore={handleShowMore}
         onPostClick={handlePostClick}
+        onSortChange={handleSortChange}
       />
       <Footer />
     </div>

--- a/app/blog/utils/blogUtils.ts
+++ b/app/blog/utils/blogUtils.ts
@@ -1,0 +1,48 @@
+import { BlogPost } from '@/app/(shared)/components/BlogCard';
+import { blogPosts } from '../data/blogPosts';
+
+/**
+ * 추천 포스트만 필터링하여 반환
+ * @returns 추천 포스트 배열
+ */
+export const getFeaturedPosts = (): BlogPost[] => {
+  return blogPosts.filter((post) => post.featured);
+};
+
+/**
+ * ID로 특정 포스트 검색
+ * @param id - 검색할 포스트 ID
+ * @returns 해당 ID의 포스트 또는 undefined
+ */
+export const getPostById = (id: number): BlogPost | undefined => {
+  return blogPosts.find((post) => post.id === id);
+};
+
+/**
+ * 페이지네이션을 위한 포스트 배열 반환
+ * @param page - 페이지 번호 (1부터 시작)
+ * @param limit - 페이지당 포스트 수 (기본값: 9)
+ * @returns 해당 페이지의 포스트 배열
+ */
+export const getPostsByPage = (page: number, limit: number = 9): BlogPost[] => {
+  const start = (page - 1) * limit;
+  const end = start + limit;
+  return blogPosts.slice(start, end);
+};
+
+/**
+ * 전체 포스트 개수 반환
+ * @returns 전체 포스트 개수
+ */
+export const getTotalPostsCount = (): number => {
+  return blogPosts.length;
+};
+
+/**
+ * 전체 페이지 수 계산
+ * @param limit - 페이지당 포스트 수 (기본값: 9)
+ * @returns 전체 페이지 수
+ */
+export const getTotalPages = (limit: number = 9): number => {
+  return Math.ceil(blogPosts.length / limit);
+};

--- a/public/chevron-down.svg
+++ b/public/chevron-down.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5.22705 7.5L10.227 12.5L15.227 7.5" stroke="#121212" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## 📝 변경 사항

1. 블로그 페이지 추가
2. 정렬버튼 컴포넌트 추가
3. 블로그 카드 공통 컴포넌트 추가
4. JSDOC function 에 추가

## 🔍 변경 사항 세부 설명

- 

## 🕵️‍♀️ 요청사항

- 

## 📷 스크린샷 (선택)

- 데스크톱
<img width="1722" height="1829" alt="image" src="https://github.com/user-attachments/assets/18b9ae4b-ebef-4fa8-b25f-e1e5d03308d5" />

- 모바일
<img width="563" height="1733" alt="image" src="https://github.com/user-attachments/assets/2b3c6cbe-23c7-4fad-be0d-ed5fd5aff659" />


- 드롭다운 작동 및 카테고리

https://github.com/user-attachments/assets/2332a767-ebad-4070-8899-e48ceb3b68cb


