### PR TITLE
Qi1 192 실시간 매칭 페이지 쓸모없는 안내멘트 제거

### DIFF
--- a/app/match/MatchPage.tsx
+++ b/app/match/MatchPage.tsx
@@ -463,7 +463,7 @@ export default function MatchPage() {
           phone: '010-0000-0000', // 실제로는 서버에서 받아야 함
           point: 0, // 실제로는 서버에서 받아야 함
           priceGb: sellerInfo.price,
-          sellerRatingScore: request.ratingData || 1000,
+          sellerRatingScore: request.sellerRatingScore || 1000,
           status: 'ACCEPTED',
           cancelReason: null,
           type: 'buyer' as const, // 판매자 입장에서 상대방은 구매자
@@ -485,7 +485,6 @@ export default function MatchPage() {
   if (!token) {
     return (
       <div className="min-h-screen flex flex-col bg-white">
-        <Header />
         <main className="flex-1 flex items-center justify-center">
           <div className="text-center">
             <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900 mx-auto mb-4"></div>

--- a/app/match/MatchPage.tsx
+++ b/app/match/MatchPage.tsx
@@ -15,7 +15,6 @@ import { useMatchStore } from '../(shared)/stores/match-store';
 import { useAuthStore } from '../(shared)/stores/auth-store';
 import TradeCancelModal from '../(shared)/components/TradeCancelModal';
 import { toast } from 'sonner';
-import { Header } from '../(shared)/components/Header';
 import { Footer } from '../(shared)/components/Footer';
 
 interface ServerTradeData {
@@ -31,6 +30,8 @@ interface ServerTradeData {
   phone?: string;
   buyerNickname?: string;
   sellerNickName?: string;
+  sellerRatingScore?: number;
+  buyerRatingScore?: number;
   cancelReason?: string;
 }
 
@@ -182,10 +183,11 @@ export default function MatchPage() {
         phone: tradeData.phone || '010-0000-0000',
         point: tradeData.point || 0,
         priceGb: tradeData.priceGb || 0,
-        sellerRatingScore: 1000, // 기본값
+        sellerRatingScore: tradeData.sellerRatingScore,
         status: tradeData.status,
         buyerNickname: tradeData.buyerNickname,
         sellerNickName: tradeData.sellerNickName,
+        buyerRatingScore: tradeData.buyerRatingScore,
         cancelReason: tradeData.cancelReason || null,
         type: 'seller' as const,
       });

--- a/app/match/complete/CompletePage.tsx
+++ b/app/match/complete/CompletePage.tsx
@@ -23,7 +23,10 @@ export default function CompletePage() {
             : partner.sellerNickName, // seller면 buyer 정보, buyer면 seller 정보
         data: partner.dataAmount, // dataAmount를 data로 매핑
         price: partner.priceGb, // priceGb를 price로 매핑
-        rating: partner.sellerRatingScore,
+        rating:
+          userRole === 'seller'
+            ? partner.buyerRatingScore
+            : partner.sellerRatingScore,
       }
     : {
         tradeId: 789,
@@ -54,9 +57,9 @@ export default function CompletePage() {
   const completedAt = new Date().toLocaleString();
 
   // 보상 정보
-  const pointsEarned = 2;
-  const bonusPoints = 5; // 첫 거래 보너스
-  const experienceGained = 25;
+  const pointsEarned = 0;
+  const bonusPoints = 0; // 첫 거래 보너스
+  const experienceGained = 10;
 
   return (
     <div className="min-h-screen flex flex-col bg-black">

--- a/app/match/complete/CompletePage.tsx
+++ b/app/match/complete/CompletePage.tsx
@@ -9,8 +9,6 @@ import EarningsDisplay from './components/EarningsDisplay';
 import ActionButtons from './components/ActionButtons';
 export default function CompletePage() {
   const { partner, userRole } = useMatchStore();
-  console.log('마지막보자:', partner);
-  console.log('현재 사용자 역할:', userRole);
 
   // 거래 상대방 정보 (store에서 가져오거나 기본값)
   const partnerInfo = partner
@@ -57,9 +55,9 @@ export default function CompletePage() {
   const completedAt = new Date().toLocaleString();
 
   // 보상 정보
-  const pointsEarned = 0;
-  const bonusPoints = 0; // 첫 거래 보너스
-  const experienceGained = 10;
+  const POINTS_EARNED = 0;
+  const BONUS_POINTS = 0; // 첫 거래 보너스
+  const EXPERIENCE_GAINED = 10;
 
   return (
     <div className="min-h-screen flex flex-col bg-black">
@@ -84,9 +82,9 @@ export default function CompletePage() {
               />
 
               <EarningsDisplay
-                pointsEarned={pointsEarned}
-                bonusPoints={bonusPoints}
-                experienceGained={experienceGained}
+                pointsEarned={POINTS_EARNED}
+                bonusPoints={BONUS_POINTS}
+                experienceGained={EXPERIENCE_GAINED}
               />
             </div>
 

--- a/app/match/complete/components/ActionButtons.tsx
+++ b/app/match/complete/components/ActionButtons.tsx
@@ -6,6 +6,8 @@ import { toast } from 'sonner';
 import { api } from '@/app/(shared)/utils/api';
 import { getApiErrorInfo } from '@/app/(shared)/types/api-errors';
 import { MatchPartner } from '@/app/(shared)/stores/match-store';
+import { SNACK_GRADES } from '@/app/(shared)/constants/snack-grades';
+import Image from 'next/image';
 
 interface ActionButtonsProps {
   partner: MatchPartner & {
@@ -21,6 +23,12 @@ export default function ActionButtons({ partner }: ActionButtonsProps) {
   const [isFavorite, setIsFavorite] = useState(false);
   const [isCheckingFavorite, setIsCheckingFavorite] = useState(true);
   const [isToggling, setIsToggling] = useState(false);
+
+  // 바삭스코어에 따른 등급 계산
+  const currentGrade =
+    SNACK_GRADES.find(
+      (grade) => partner.rating >= grade.min && partner.rating <= grade.max
+    ) || SNACK_GRADES[0];
 
   const handleNewMatch = () => {
     router.push('/match');
@@ -130,9 +138,18 @@ export default function ActionButtons({ partner }: ActionButtonsProps) {
                 <h3 className="text-lg font-bold text-white mb-1">
                   {partner.name}
                 </h3>
-                <p className="text-gray-400 text-sm">
-                  평점: ⭐ {partner.rating}
-                </p>
+
+                <div className="flex items-center space-x-2">
+                  <Image
+                    src={currentGrade.icon}
+                    alt={currentGrade.name}
+                    width={16}
+                    height={16}
+                  />
+                  <p className="text-gray-400 text-sm">
+                    바삭스코어: {partner.rating}
+                  </p>
+                </div>
               </div>
               <div className="text-right">
                 <p className="text-green-400 font-bold">{partner.data}GB</p>

--- a/app/match/complete/components/EarningsDisplay.tsx
+++ b/app/match/complete/components/EarningsDisplay.tsx
@@ -4,18 +4,15 @@ import Image from 'next/image';
 import React from 'react';
 
 interface EarningsDisplayProps {
-  pointsEarned: number;
+  pointsEarned?: number;
   experienceGained: number;
   bonusPoints?: number;
 }
 
 export default function EarningsDisplay({
-  pointsEarned,
   experienceGained,
   bonusPoints = 0,
 }: EarningsDisplayProps) {
-  const totalPoints = pointsEarned + bonusPoints;
-
   return (
     <div className="relative bg-gray-800/30 backdrop-blur-sm rounded-2xl border border-gray-700/50 shadow-2xl overflow-hidden">
       {/* 서브틀한 글로우 효과 */}
@@ -28,7 +25,7 @@ export default function EarningsDisplay({
 
         <div className="space-y-6">
           {/* 기본 포인트 */}
-          <div className="flex items-center justify-between p-6 bg-blue-900/20 border border-blue-400/30 rounded-xl backdrop-blur-sm">
+          {/* <div className="flex items-center justify-between p-6 bg-blue-900/20 border border-blue-400/30 rounded-xl backdrop-blur-sm">
             <div className="flex items-center space-x-4">
               <div className="w-12 h-12 bg-gradient-to-r from-blue-400 to-blue-500 rounded-full flex items-center justify-center shadow-lg shadow-blue-400/25">
                 <span className="text-black text-xl">💰</span>
@@ -41,7 +38,7 @@ export default function EarningsDisplay({
             <div className="text-3xl font-bold text-blue-400 animate-pulse">
               +{pointsEarned}
             </div>
-          </div>
+          </div> */}
 
           {/* 보너스 포인트 */}
           {bonusPoints > 0 && (
@@ -87,20 +84,6 @@ export default function EarningsDisplay({
         </div>
 
         {/* 총 합계 - 특별한 강조 */}
-        <div className="border-t border-gray-700/50 pt-8 mt-8">
-          <div className="flex items-center justify-between p-6 bg-green-900/20 border border-green-400/30 rounded-xl backdrop-blur-sm">
-            <span className="text-xl font-bold text-green-300">총 포인트</span>
-            <div className="relative">
-              <span className="text-4xl font-bold text-green-400 animate-pulse">
-                +{totalPoints}
-              </span>
-              {/* 글로우 효과 */}
-              <div className="absolute inset-0 text-4xl font-bold text-green-400 animate-ping opacity-20">
-                +{totalPoints}
-              </div>
-            </div>
-          </div>
-        </div>
       </div>
     </div>
   );

--- a/app/match/components/IncomingRequestsPanel.tsx
+++ b/app/match/components/IncomingRequestsPanel.tsx
@@ -117,8 +117,8 @@ function RequestCard({
             <div className="flex items-center gap-2 mb-3">
               <div className="w-2 h-2 bg-orange-400 rounded-full animate-pulse"></div>
               <p className="font-medium text-white">
-                <span className="text-orange-400">{request.buyerName}</span>님의
-                거래 요청
+                <span className="text-orange-400">{request.buyerNickname}</span>
+                님의 거래 요청
               </p>
             </div>
 

--- a/app/match/trading/TradingPage.tsx
+++ b/app/match/trading/TradingPage.tsx
@@ -312,8 +312,6 @@ export default function TradingPage() {
 
   return (
     <div className="min-h-screen flex flex-col bg-gradient-to-br from-green-400/5 via-transparent to-green-300/3">
-      <Header isTrading={true} />
-
       {/* 헤더 */}
       <TradingHeader
         timeLeft={timeLeft}

--- a/app/match/trading/TradingPage.tsx
+++ b/app/match/trading/TradingPage.tsx
@@ -16,7 +16,6 @@ import WaitingPaymentStep from './components/WaitingPaymentStep';
 import ShowPhoneStep from './components/ShowPhoneStep';
 import UploadDataStep from './components/UploadDataStep';
 import TradeCancelModal from '@/app/(shared)/components/TradeCancelModal';
-import { Header } from '@/app/(shared)/components/Header';
 
 type TradingStep =
   | 'confirmation'

--- a/app/match/trading/components/ConfirmationStep.tsx
+++ b/app/match/trading/components/ConfirmationStep.tsx
@@ -111,9 +111,7 @@ export default function ConfirmationStep({
                   </div>
                   <div className="flex items-center space-x-2">
                     <span className="text-white font-semibold">
-                      {partner.type === 'seller'
-                        ? partner.buyerRatingScore
-                        : partner.sellerRatingScore}
+                      {partnerRating}
                     </span>
                   </div>
                 </div>

--- a/app/match/trading/components/ConfirmationStep.tsx
+++ b/app/match/trading/components/ConfirmationStep.tsx
@@ -3,6 +3,8 @@
 import React from 'react';
 import { MatchPartner } from '@/app/(shared)/stores/match-store';
 import { useGlobalWebSocket } from '@/app/(shared)/hooks/useGlobalWebSocket';
+import { SNACK_GRADES } from '@/app/(shared)/constants/snack-grades';
+import Image from 'next/image';
 
 interface ConfirmationStepProps {
   partner: MatchPartner;
@@ -15,6 +17,17 @@ export default function ConfirmationStep({
   onNext,
 }: ConfirmationStepProps) {
   useGlobalWebSocket();
+
+  // 바삭스코어에 따른 등급 계산
+  const partnerRating =
+    partner.type === 'seller'
+      ? partner.buyerRatingScore
+      : partner.sellerRatingScore;
+
+  const currentGrade =
+    SNACK_GRADES.find(
+      (grade) => partnerRating >= grade.min && partnerRating <= grade.max
+    ) || SNACK_GRADES[0];
   return (
     <div className="max-w-3xl mx-auto px-4 ">
       {/* 메인 카드 */}
@@ -85,7 +98,12 @@ export default function ConfirmationStep({
             <div className="bg-gray-800/50 backdrop-blur-sm rounded-xl p-4 border border-gray-700/50">
               <div className="flex items-center space-x-3">
                 <div className="w-10 h-10 bg-yellow-400/20 rounded-full flex items-center justify-center">
-                  <span className="text-yellow-400 text-lg">⭐</span>
+                  <Image
+                    src={currentGrade.icon}
+                    alt={currentGrade.name}
+                    width={16}
+                    height={16}
+                  />
                 </div>
                 <div>
                   <div className="text-gray-400 text-sm">

--- a/app/match/trading/components/ConfirmationStep.tsx
+++ b/app/match/trading/components/ConfirmationStep.tsx
@@ -93,7 +93,9 @@ export default function ConfirmationStep({
                   </div>
                   <div className="flex items-center space-x-2">
                     <span className="text-white font-semibold">
-                      {partner.sellerRatingScore}
+                      {partner.type === 'seller'
+                        ? partner.buyerRatingScore
+                        : partner.sellerRatingScore}
                     </span>
                   </div>
                 </div>
@@ -139,7 +141,6 @@ export default function ConfirmationStep({
                   <br />• 중간에 취소할 경우{' '}
                   <span className="text-orange-300 font-medium">패널티</span>가
                   부과될 수 있습니다
-                  <br />• 상대방과의 원활한 소통을 위해 채팅을 확인해주세요
                 </div>
               </div>
             </div>

--- a/app/match/trading/components/TradingSteps.tsx
+++ b/app/match/trading/components/TradingSteps.tsx
@@ -98,7 +98,7 @@ export default function TradingSteps({
                         : 'text-gray-600'
                     }`}
                   >
-                    {index + 1}/4
+                    {index + 1}/{STEPS.length}
                   </div>
                 </div>
 

--- a/app/match/trading/components/TransferStep.tsx
+++ b/app/match/trading/components/TransferStep.tsx
@@ -119,9 +119,7 @@ export default function TransferStep() {
                 <div className="text-blue-200/80 text-sm space-y-1">
                   <p>
                     • 평균 전송 시간:{' '}
-                    <span className="text-blue-300 font-medium">
-                      30초 ~ 1분
-                    </span>
+                    <span className="text-blue-300 font-medium">1분 ~ 3분</span>
                   </p>
                   <p>• 전송 완료 시 자동으로 다음 단계로 진행됩니다</p>
                   <p>• 네트워크 상태에 따라 시간이 다를 수 있습니다</p>


### PR DESCRIPTION
## 📝 변경 사항

1. 불필요한 거래 문구들 제거
2. trading 페이지 헤더 2개 제거 (layout에 추가된듯)
3. 구매자 레이팅 스코어 반영되지 않던 문제 수정
4. 바삭스코어에 따라 아이콘으로 보이게 수정
5. 이메일 -> 전부 닉네임으로 보이게 수정

## 🔍 변경 사항 세부 설명

- 

## 🕵️‍♀️ 요청사항

- 

## 📷 스크린샷 (선택)

<img width="1250" height="517" alt="image" src="https://github.com/user-attachments/assets/eb7b1943-1d8b-40c9-8441-4316837d5332" />


<img width="814" height="408" alt="image" src="https://github.com/user-attachments/assets/1642da59-87e7-4c45-a829-5147b89d8652" />
