### PR TITLE
QI1-214-실시간-페이지-햄버거-누를때-다크모드-설정

### DIFF
--- a/app/(shared)/components/Header.tsx
+++ b/app/(shared)/components/Header.tsx
@@ -78,6 +78,8 @@ export const Header: FC<HeaderProps> = ({ isTrading = false }) => {
   const pathname = usePathname();
   const router = useRouter();
 
+  const isAdminPage = pathname?.startsWith('/admin');
+
   const { actualTheme, changeTheme } = useTheme();
   const isDark = actualTheme === 'dark';
   const [menuOpen, setMenuOpen] = useState(false);
@@ -107,7 +109,7 @@ export const Header: FC<HeaderProps> = ({ isTrading = false }) => {
   return (
     <>
       <header
-        className={`w-full h-[57px] md:h-[67px] px-6 flex justify-between items-center relative transition-colors duration-300 z-50 ${
+        className={`w-full h-[57px] md:h-[67px] px-6 flex justify-between items-center relative transition-colors duration-300 ${isAdminPage ? 'z-10' : 'z-50'} ${
           isDarkmode
             ? 'bg-gradient-to-r from-gray-900 via-black to-gray-900 border-b border-gray-800/50'
             : 'bg-white border-b'
@@ -171,7 +173,7 @@ export const Header: FC<HeaderProps> = ({ isTrading = false }) => {
       <Transition.Root show={menuOpen} as={Fragment}>
         <Dialog
           as="div"
-          className="relative z-[9999] md:hidden"
+          className={`relative md:hidden ${isAdminPage ? 'z-10' : 'z-[9999]'}`}
           onClose={setMenuOpen}
         >
           <Transition.Child
@@ -199,7 +201,8 @@ export const Header: FC<HeaderProps> = ({ isTrading = false }) => {
             leaveTo="opacity-0 -translate-y-4"
           >
             <Dialog.Panel
-              className="fixed left-0 w-full z-10 bg-white dark:bg-gray-900 px-4 py-4 flex flex-col gap-1 rounded-b-2xl shadow-none"
+              // [수정] isDarkmode 변수를 사용하여 동적으로 배경색을 지정합니다.
+              className={`fixed left-0 w-full z-10 px-4 py-4 flex flex-col gap-1 rounded-b-2xl shadow-none ${isDarkmode ? 'bg-gray-900' : 'bg-white'}`}
               style={{
                 top:
                   typeof window !== 'undefined' && window.innerWidth >= 768


### PR DESCRIPTION
## 📝 변경 사항

1. 실시간 매칭(_/_match) 페이지에서는 모바일 메뉴(햄버거 메뉴)가 열릴 때도 페이지의 다크 모드 테마가 일관되게 적용되도록 배경색 로직을 수정어요!

## 🔍 변경 사항 세부 설명

- 

## 🕵️‍♀️ 요청사항

- 

## 📷 스크린샷 (선택)
비포
<img width="413" height="448" alt="image" src="https://github.com/user-attachments/assets/ef19a739-a384-4953-9b51-fbf6c06d6ac6" />
애프터
<img width="395" height="716" alt="image" src="https://github.com/user-attachments/assets/0bc2b42a-df91-43f6-9eeb-168d3b5c1694" />
